### PR TITLE
ansible-drift: ignore errors while installing roles and collections

### DIFF
--- a/templates/ansible-drift.j2
+++ b/templates/ansible-drift.j2
@@ -30,7 +30,7 @@ if [ -n "$branch" ]; then
   git submodule update --init --recursive --quiet
 
   if [ -f requirements.yml ]; then
-    ansible-galaxy install -r requirements.yml --force >/dev/null 2>&1
+    ansible-galaxy install --ignore-errors -r requirements.yml --force >/dev/null 2>&1
   fi
 
   message="$message from $branch"


### PR DESCRIPTION
This should ideally improve error handling in regards to connection issues, like "The read operation timed out", which seem to happen more frequently.

Obviously, that's not a proper solution, as calls which throw transient errors should probably be retried, instead of being ignored and skipped over, but it might help as a quick fix.