### PR TITLE
ansible-drift: bump SSH reconnection retries

### DIFF
--- a/templates/ansible-drift.j2
+++ b/templates/ansible-drift.j2
@@ -13,6 +13,7 @@ export ANSIBLE_DEPRECATION_WARNINGS=no
 export ANSIBLE_COMMAND_WARNINGS=no
 export ANSIBLE_DISPLAY_OK_HOSTS=no
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=no
+export ANSIBLE_SSH_RETRIES=10
 export ANSIBLE_STDOUT_CALLBACK=actionable
 
 # check argument and construct vars


### PR DESCRIPTION
Ansible retries connections only if it gets an SSH error with a return code of 255, however, by default, reconnection retries are disabled.

This change makes Ansible try up to ten times, which ideally adresses intermittent errors, like network glitches, which otherwise lead to noisy emails about the machine in question being UNREACHABLE.